### PR TITLE
Only linkify text nodes

### DIFF
--- a/jquery.linkify.js
+++ b/jquery.linkify.js
@@ -40,7 +40,18 @@ function linkify(string, buildHashtagUrl, includeW3, target) {
           }
         }
       }
-      $this.html(linkify($this.html(), buildHashtagUrl, includeW3, target));
+      $this.html(
+          $.map(
+            $this.contents(),
+            function(n, i) {
+                if (n.nodeType == 3) {
+                    return linkify(n.data, buildHashtagUrl, includeW3, target);
+                } else {
+                    return n.outerHTML;
+                }
+            }
+        ).join("")
+      );
     });
   }
 })(jQuery);


### PR DESCRIPTION
If one runs linkify twice on the same content or on content that already has marked-up links (e.g. markdown), the old code would break. This new code only touches text nodes.
